### PR TITLE
Fixed Attack Bug

### DIFF
--- a/Gettin Griddy/Assets/Scripts/PlayerBehaviour.cs
+++ b/Gettin Griddy/Assets/Scripts/PlayerBehaviour.cs
@@ -57,6 +57,7 @@ public class PlayerBehaviour : GridMovement
                 enemy.TakeDamage();
             }
         }
+        tilesToAttack.Clear();
         gm.playerTile = GetTile();
         GetComponent<Renderer>().material.color = Color.green;
         gm.EndTurn();


### PR DESCRIPTION
When the players turn ended the tiles to attack were not being cleared and allowing the player to damage tiles they weren't attacking.